### PR TITLE
verbose logging for label creation failure

### DIFF
--- a/lib/plugins/labels.js
+++ b/lib/plugins/labels.js
@@ -76,7 +76,12 @@ module.exports = class Labels extends Diffable {
       ])
     }
     this.log.debug(`Creating labels for ${JSON.stringify(attrs, null, 4)}`)
-    return this.github.issues.createLabel(this.wrapAttrs(attrs)).catch(e => this.logError(` ${JSON.stringify(e)}`))
+    return this.github.issues.createLabel(this.wrapAttrs(attrs)).catch(e => {
+      this.log.debug('Label creation failed')
+      this.log.error('Label creation failed - message:', e?.message || 'No message')
+      this.log.error('Label creation failed - toString:', String(e))
+      this.log.error('Label creation failed - full error:', JSON.stringify(e, null, 2))
+    })
   }
 
   remove (existing) {


### PR DESCRIPTION
This line seems capable of silently failing and then also not logging anything. I suspect the JSON serialization might be failing, but I'm not completely sure. Going with additional logging just to see if we can get anything out of this.